### PR TITLE
test, feat(font): callout, large_title, title_one, title_two

### DIFF
--- a/lib/motion-dynamic-type/font.rb
+++ b/lib/motion-dynamic-type/font.rb
@@ -4,7 +4,7 @@ module MotionDynamicType
       def body
         UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
       end
-
+      
       def headline
         UIFont.preferredFontForTextStyle(UIFontTextStyleHeadline)
       end
@@ -24,6 +24,27 @@ module MotionDynamicType
       def footnote
         UIFont.preferredFontForTextStyle(UIFontTextStyleFootnote)
       end
+      
+      def callout
+        UIFont.preferredFontForTextStyle(UIFontTextStyleCallout)
+      end
+      
+      def large_title
+        UIFont.preferred.FontForTextStyle(UIFontTextStyleLargeTitle)
+      end
+      
+      def title_one
+        UIFont.preferred.FontForTextStyle(UIFontTextStyleTitle1)
+      end
+      
+      def title_two
+        UIFont.preferred.FontForTextStyle(UIFontTextStyleTitle2)
+      end
+      
+      def title_three
+        UIFont.preferred.FontForTextStyle(UIFontTextStyleTitle3)
+      end
+
     end
   end
 end

--- a/lib/motion-dynamic-type/font.rb
+++ b/lib/motion-dynamic-type/font.rb
@@ -30,19 +30,19 @@ module MotionDynamicType
       end
       
       def large_title
-        UIFont.preferred.FontForTextStyle(UIFontTextStyleLargeTitle)
+        UIFont.preferredFontForTextStyle(UIFontTextStyleLargeTitle)
       end
       
       def title_one
-        UIFont.preferred.FontForTextStyle(UIFontTextStyleTitle1)
+        UIFont.preferredFontForTextStyle(UIFontTextStyleTitle1)
       end
       
       def title_two
-        UIFont.preferred.FontForTextStyle(UIFontTextStyleTitle2)
+        UIFont.preferredFontForTextStyle(UIFontTextStyleTitle2)
       end
       
       def title_three
-        UIFont.preferred.FontForTextStyle(UIFontTextStyleTitle3)
+        UIFont.preferredFontForTextStyle(UIFontTextStyleTitle3)
       end
 
     end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -21,7 +21,6 @@ describe MotionDynamicType::Font do
   end
 
   describe "#subhead" do
-
     it "should have the same font descriptor as the subheadline font descriptor when asked for the subheadline font" do
       mdt_font_descriptor = MotionDynamicType::Font.subhead.fontDescriptor
       ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleSubheadline)
@@ -31,7 +30,6 @@ describe MotionDynamicType::Font do
   end
 
   describe "#caption_one" do
-
     it "should have the same font descriptor as the caption one font descriptor when asked for the caption one font" do
       mdt_font_descriptor = MotionDynamicType::Font.caption_one.fontDescriptor
       ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleCaption1)
@@ -59,5 +57,45 @@ describe MotionDynamicType::Font do
     end
 
   end
+  
+  describe '#callout' do
+  it "should have the same font descriptor as the callout font descriptor when asked for the callout font"
+    mdt_font_descriptor = MotionDynamicType::Font.callout.fontDescriptor
+    ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleCallout)
+    mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
+  end
+end
+
+describe '#large_title' do
+  it "should have the same font descriptor as the large title font descriptor when asked for the large title font"
+    mdt_font_descriptor = MotionDynamicType::Font.large_title.fontDescriptor
+    ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleLargeTitle)
+    mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
+  end
+end
+
+describe '#title_one' do
+  it "should have the same font descriptor as the title one font descriptor when asked for the title one font"
+    mdt_font_descriptor = MotionDynamicType::Font.title_one.fontDescriptor
+    ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleTitle1)
+    mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
+  end
+end
+
+describe '#title_two' do
+  it "should have the same font descriptor as the title two font descriptor when asked for the title two font"
+    mdt_font_descriptor = MotionDynamicType::Font.title_two.fontDescriptor
+    ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleTitle2)
+    mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
+  end
+end
+
+describe '#title_three' do
+  it "should have the same font descriptor as the title three font descriptor when asked for the title three font"
+    mdt_font_descriptor = MotionDynamicType::Font.title_three.fontDescriptor
+    ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleTitle3)
+    mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
+  end
+end
 
 end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -59,7 +59,7 @@ describe MotionDynamicType::Font do
   end
   
   describe '#callout' do
-  it "should have the same font descriptor as the callout font descriptor when asked for the callout font"
+  it "should have the same font descriptor as the callout font descriptor when asked for the callout font" do
     mdt_font_descriptor = MotionDynamicType::Font.callout.fontDescriptor
     ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleCallout)
     mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
@@ -67,7 +67,7 @@ describe MotionDynamicType::Font do
 end
 
 describe '#large_title' do
-  it "should have the same font descriptor as the large title font descriptor when asked for the large title font"
+  it "should have the same font descriptor as the large title font descriptor when asked for the large title font" do
     mdt_font_descriptor = MotionDynamicType::Font.large_title.fontDescriptor
     ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleLargeTitle)
     mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
@@ -75,7 +75,7 @@ describe '#large_title' do
 end
 
 describe '#title_one' do
-  it "should have the same font descriptor as the title one font descriptor when asked for the title one font"
+  it "should have the same font descriptor as the title one font descriptor when asked for the title one font" do
     mdt_font_descriptor = MotionDynamicType::Font.title_one.fontDescriptor
     ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleTitle1)
     mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
@@ -83,7 +83,7 @@ describe '#title_one' do
 end
 
 describe '#title_two' do
-  it "should have the same font descriptor as the title two font descriptor when asked for the title two font"
+  it "should have the same font descriptor as the title two font descriptor when asked for the title two font" do
     mdt_font_descriptor = MotionDynamicType::Font.title_two.fontDescriptor
     ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleTitle2)
     mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]
@@ -91,7 +91,7 @@ describe '#title_two' do
 end
 
 describe '#title_three' do
-  it "should have the same font descriptor as the title three font descriptor when asked for the title three font"
+  it "should have the same font descriptor as the title three font descriptor when asked for the title three font" do
     mdt_font_descriptor = MotionDynamicType::Font.title_three.fontDescriptor
     ui_font_descriptor = UIFontDescriptor.preferredFontDescriptorWithTextStyle(UIFontTextStyleTitle3)
     mdt_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"].should == ui_font_descriptor.fontAttributes["NSCTFontUIUsageAttribute"]


### PR DESCRIPTION
Added the missing text styles from UIFontTextStyles.

Was there a reason why they weren't added?